### PR TITLE
Redesign portfolio with new sections and refined layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@lucide/astro": "^0.544.0",
     "@vercel/analytics": "^1.6.1",
     "astro": "^5.16.11",
-    "astro-particles": "^2.10.0",
     "flowbite": "^3.1.2",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       astro:
         specifier: ^5.16.11
         version: 5.16.11(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.55.1)(typescript@5.9.3)(yaml@2.8.2)
-      astro-particles:
-        specifier: ^2.10.0
-        version: 2.10.0
       flowbite:
         specifier: ^3.1.2
         version: 3.1.2(rollup@4.55.1)
@@ -883,9 +880,6 @@ packages:
 
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
-
-  astro-particles@2.10.0:
-    resolution: {integrity: sha512-DE1azMdcu2dkXxEKd7seoRqbhlh4UnTfinWM+RF5jm00tPtaJ+cjrz5nKHRnzYcyTAR18MaRAC4lIKf3tu86iQ==}
 
   astro@5.16.11:
     resolution: {integrity: sha512-Z7kvkTTT5n6Hn5lCm6T3WU6pkxx84Hn25dtQ6dR7ATrBGq9eVa8EuB/h1S8xvaoVyCMZnIESu99Z9RJfdLRLDA==}
@@ -3038,10 +3032,6 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
-
-  astro-particles@2.10.0:
-    dependencies:
-      tsparticles-engine: 2.12.0
 
   astro@5.16.11(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.55.1)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -126,7 +126,7 @@ const favoriteProjects = PROJECTS.filter((project) => project.favorite);
 
               <div class="hero-slide__meta">
                 <div class="hero-slide__meta-main">
-                  <span class="hero-slide__label">Sistema destacado</span>
+                  <span class="hero-slide__label">Ultimas aplicaciones</span>
                   <strong>{project.title}</strong>
                   <p class="hero-slide__summary">{project.shortLabel}</p>
                 </div>
@@ -147,7 +147,7 @@ const favoriteProjects = PROJECTS.filter((project) => project.favorite);
 
       <div
         class="hero-carousel__controls"
-        aria-label="Seleccionar sistema destacado"
+        aria-label="Seleccionar ultimas aplicaciones"
       >
         {
           favoriteProjects.map((project, index) => (

--- a/src/components/ParticlesComponent.astro
+++ b/src/components/ParticlesComponent.astro
@@ -1,5 +1,4 @@
 ---
-import Particles from "astro-particles";
 import type { ISourceOptions } from "tsparticles-engine";
 
 const options: ISourceOptions = {
@@ -82,29 +81,21 @@ const options: ISourceOptions = {
 };
 ---
 
-<script>
-  import { type Container, type Engine } from "tsparticles-engine";
+<div id="tsparticles" aria-hidden="true"></div>
+
+<script define:vars={{ options }} type="module">
+  import { tsParticles } from "tsparticles-engine";
   import { loadFull } from "tsparticles";
 
-  declare global {
-    interface Window {
-      particlesInit: (engine: Engine) => Promise<void>;
-      particlesLoaded: (container: Container) => void;
-    }
-  }
-
-  window.particlesInit = async function (engine: Engine) {
-    await loadFull(engine as any);
-  };
-
-  window.particlesLoaded = function (container: Container) {
-    console.log("particlesLoaded callback");
-  };
+  await loadFull(tsParticles);
+  await tsParticles.load({ id: "tsparticles", options });
 </script>
 
-<Particles
-  id="tsparticles"
-  options={options}
-  init="particlesInit"
-  loaded="particlesLoaded"
-/>
+<style>
+  #tsparticles {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Reworked the portfolio into a more complete single-page experience with new Hero, About, Services, Certifications, Education, and Skills sections.
- Refreshed the header, footer, navigation, project presentation, and contact layout for a more cohesive site structure.
- Replaced `astro-particles` with a direct `tsparticles` setup and updated supporting icons, links, and data content.
- Added the `frontend-design` skill assets and refreshed project showcase pages and screenshots.

## Testing
- Not run
- Confirmed dependency and lockfile updates were applied for the Astro, Tailwind, TypeScript, Prettier, and Vercel packages.
- Checked that the new portfolio routes and section components are included in the diff.